### PR TITLE
Detecting current section fix

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -127,16 +127,22 @@
 		},
 		
 		getSection: function(windowPos) {
-			var returnValue = null;
+			var currentSection = null;
+			var lastSection = null;
 			var windowHeight = Math.round(this.$win.height() * this.config.scrollThreshold);
+			var atTheBottom = windowPos >= this.docHeight - this.$win.height();
+			var currentPosition = windowPos + windowHeight;
 
 			for(var section in this.sections) {
-				if((this.sections[section] - windowHeight) < windowPos) {
-					returnValue = section;
+				if(this.sections[section] >= this.sections[lastSection || section]) {
+					lastSection = section;
+				}
+				if(this.sections[section] < currentPosition && this.sections[section] >= this.sections[currentSection || section]) {
+					currentSection = section;
 				}
 			}
 			
-			return returnValue;
+			return atTheBottom ? lastSection : currentSection;
 		},
 		
 		handleClick: function(e) {


### PR DESCRIPTION
We run into some issues when our top nav was ordered differently than the sections on the page. In our case the link to the top section was moved from the first position to the last which made it always be returned.
This change fixes the issue and makes sure that when you are at the bottom of your page, last section is being returned even if it's to small to be chosen based on regular calculations.
