### PR TITLE
update jquery.nav.js to handle misordered lists

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -113,16 +113,16 @@
 			var self = this;
 			var linkHref;
 			var topPos;
-			var $target;
-			
+			var targets = [];
+
 			self.$nav.each(function() {
 				linkHref = self.getHash($(this));
-				$target = $('#' + linkHref);
-
-				if($target.length) {
-					topPos = $target.offset().top;
-					self.sections[linkHref] = Math.round(topPos) - self.config.scrollOffset;
-				}
+				targets.push('#' + linkHref);
+			});
+			$(targets.join(',')).each(function(){
+				var $target = $(this);
+				topPos = $target.offset().top;
+				self.sections[$target.attr('id')] = Math.round(topPos) - self.config.scrollOffset;
 			});
 		},
 		


### PR DESCRIPTION
when you need to change order of the list items, for example because of float:right, getPositions will not work corectly, i've patched it to not count on right order of list items, but order of targets in html
