### PR TITLE
Unfix jquery version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
     "*.css"
   ],
   "dependencies": {
-    "jquery": "~1.8.0"
+    "jquery": ">=1.8.0"
   }
 }


### PR DESCRIPTION
jQuery-One-Page-Nav would not allow installing a jQuery version later than 1.8. :(