### PR TITLE
Added missing scrollChange call in handleClick

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -158,6 +158,12 @@
 
 				//Scroll to the correct position
 				self.scrollTo(newLoc, function() {
+					
+			               //Scroll change callback
+			               if(self.config.scrollChange){
+			                  self.config.scrollChange($parent);
+			               }
+					
 					//Do we need to change the hash?
 					if(self.config.changeHash) {
 						window.location.hash = newLoc;


### PR DESCRIPTION
If a menu item was clicked to scroll to the specified anchor, the 'scrollChange' callback function was not fired.
Calling the scrollChange right before self.scrollTo or just within it is arguable
