### PR TITLE
Handle case of multiple hashes in url

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -105,7 +105,8 @@
 		},
 
 		getHash: function($link) {
-			return $link.attr('href').split('#')[1];
+			var parts = $link.attr('href').split('#');
+			return parts[parts.length - 1];
 		},
 
 		getPositions: function() {


### PR DESCRIPTION
Sometimes you can have more than one hash character in the link, for example in an angular app.
