### PR TITLE
Scroll offset

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -120,7 +120,7 @@
 				$target = $('#' + linkHref);
 
 				if($target.length) {
-					topPos = $target.offset().top;
+					topPos = $target.offset().top + self.config.scrollOffset;
 					self.sections[linkHref] = Math.round(topPos);
 				}
 			});
@@ -201,7 +201,8 @@
 
 		scrollTo: function(target, callback) {
 			var offset = $(target).offset().top,
-                            scrollOffset: this.config.scrollOffset;
+                            scrollOffset = this.config.scrollOffset;
+
 
 			$('html, body').animate({
 				scrollTop: offset + scrollOffset


### PR DESCRIPTION
It might be the case that we want to scroll to a position other than `target.offset().top`. This PR adds a `scrollOffset` option to specify an offset to `target.offset().top`

Hope it helps.
