### PR TITLE
hide mobile navigation bar after navigation

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -156,6 +156,12 @@
 				//Removing the auto-adjust on scroll
 				self.unbindInterval();
 
+				//Hide mobile menu if open
+				var $nav = $('nav.collapse.in');
+				if ($nav.length > 0 && typeof $.fn.collapse !== 'undefined') {
+				    $nav.collapse('hide');
+				}
+
 				//Scroll to the correct position
 				self.scrollTo(newLoc, function() {
 					//Do we need to change the hash?


### PR DESCRIPTION
When using this plugin with Bootstrap (a fairly common usage) the mobile navigation bar won't automatically close after navigating to a section. This PR automatically collapses the mobile menu after navigation so that the user doesn't have to manually close it to read content.

The change is unobtrusive and will do nothing if not using Bootstrap and/or not using the collapse plugin.
