### PR TITLE
Change location.hash *before* scrolling.

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -158,7 +158,20 @@
 
 				//Do we need to change the hash?
 				if(self.config.changeHash) {
-					window.location.hash = newLoc;
+					// We need to insert a temp. link element to avoid breaking
+					// the broweser history.
+					var elem = document.getElementById(id);
+					var $a = $('<a> </a>').attr('id', id).css({
+							position: 'absolute',
+							top: $(window).scrollTop(),
+							left: $(window).scrollLeft()
+						});
+
+					elem.id = '';
+					$('body').prepend($a);
+					location.hash = newLoc;
+					$a.remove();
+					elem.id = id;
 				}
 
 				//Scroll to the correct position


### PR DESCRIPTION
You have to update `location.hash` before scrolling or the browser history will break and not jump to the correct positions in the document.
