### PR TITLE
Filter the sections seen by your one-page menu

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -40,6 +40,7 @@
 			changeHash: false,
 			easing: 'swing',
 			filter: '',
+			sectionFilter: '', // ex: '[rel!=notmainmenu]'
 			scrollSpeed: 750,
 			scrollThreshold: 0.5,
 			begin: false,
@@ -117,6 +118,8 @@
 			self.$nav.each(function() {
 				linkHref = self.getHash($(this));
 				$target = $('#' + linkHref);
+				if (this.config.sectionFilter) 
+					$target = $target.filter(this.config.sectionFilter);
 
 				if($target.length) {
 					topPos = $target.offset().top;


### PR DESCRIPTION
I have 2 menus in my page (main header menu, and more detailed menu in footer).
I have an issue because when I scroll the page, the main menu detect the footer section and don't let "active" the menu item... I need to tell him to skip some section to not be spoiled. 
I propose the "sectionFilter" option, different from the filter option. Now it works like a charm.
Ex: `sectionFilter: '[rel!=notmainmenu]'`, and in the html I put `rel="notmainmenu"` on the sub sections.