### PR TITLE
Add support for npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+README.md
+*.html
+*.css

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "jquery-one-page-nav",
+  "version": "3.0.0",
+  "description": "Smooth scrolling and smart navigation when user scrolls on one-page sites.",
+  "main": "jquery.nav.js",
+  "dependencies": {
+    "jquery": ">=1.8.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/davist11/jQuery-One-Page-Nav.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/davist11/jQuery-One-Page-Nav/issues"
+  },
+  "homepage": "https://github.com/davist11/jQuery-One-Page-Nav#readme"
+}


### PR DESCRIPTION
Adds npm support.

Should close #173 

Edit: `npm init` does not support uppercase letters in name, so I used `jquery-one-page-nav`. Can be installed for testing with `npm install reback00/jQuery-One-Page-Nav#npm-support`